### PR TITLE
Typo in Opensea marketplace name, I removed the a

### DIFF
--- a/public/config/config.json
+++ b/public/config/config.json
@@ -12,7 +12,7 @@
   "WEI_COST": 75000000000000000,
   "DISPLAY_COST": 0.075,
   "GAS_LIMIT": 285000,
-  "MARKETPLACE": "Opeansea",
+  "MARKETPLACE": "Opensea",
   "MARKETPLACE_LINK": "https://opensea.io/collection/nerdy-coder-clones",
   "SHOW_BACKGROUND": true
 }


### PR DESCRIPTION
I believe I found a typo in the marketplace name, Opensea. I remove the extra "a" that was in the middle of the name.